### PR TITLE
Fix failing test: fetch full git history and add error handling

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full git history for changelog generation
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/scripts/gen_changelog.py
+++ b/scripts/gen_changelog.py
@@ -46,10 +46,15 @@ def summarize_commit(commit, client, model, max_tokens=300):
     """
     commit_message = commit.message.strip()
     parent = commit.parents[0] if commit.parents else NULL_TREE
-    diff = "\n".join(
-        d.diff.decode("utf-8", errors="ignore")
-        for d in commit.diff(parent, create_patch=True)
-    )
+
+    try:
+        diff = "\n".join(
+            d.diff.decode("utf-8", errors="ignore")
+            for d in commit.diff(parent, create_patch=True)
+        )
+    except Exception as e:
+        logging.error(f"Error getting diff for commit {commit.hexsha[:7]}: {e}")
+        diff = ""
 
     prompt = f"""
     You are an AI assistant creating a human-readable changelog.


### PR DESCRIPTION
- Add fetch-depth: 0 to checkout action to fetch full git history
- Add try-catch block around commit.diff() to handle errors gracefully
- This fixes GitCommandError when diffing commits in shallow clones